### PR TITLE
Adds MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,7 @@
-tbd
+Copyright (c) 2016 The PHP Oxford User Group, United Kindom.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 [![Issue Count](https://codeclimate.com/github/phpoxford/spires/badges/issue_count.svg)](https://codeclimate.com/github/phpoxford/spires)
 
 Spires is an IRC bot built by [PHPOxford](http://phpoxford.uk).
+
+## Contributing and Forking
+
+Please note that this project is licensed under the MIT license. We encourage forking of this project, but ask that you keep all copyright, attribution notices, and continue to use the [MIT license](/LICENSE.md) in your fork of the project.
+
+For further details on Contributing guidelines, please read the [contributing guide](/CONTRIBUTING.md).

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "Spires IRC bot",
   "homepage": "https://github.com/phpoxford/spires",
-  "license": "tbd",
+  "license": "MIT",
   "authors": [
     {
       "name": "Martin Dilling-Hansen",


### PR DESCRIPTION
Fixes #1 

Unless I have misread things it looks like we are heading down the MIT route for licensing.

This license represents my proposal that we use MIT, rather than DBAD or other. I suggest that we discuss this on Monday in IRC and if no-one has any major objections we can merge. If there are objections I suggest that you get a move on and add them to this issue: https://github.com/phpoxford/spires-irc/issues/1
