### PR TITLE
BangMessage learnt "bangCommand()" and new TestCase class added

### DIFF
--- a/src/Irc/Client.php
+++ b/src/Irc/Client.php
@@ -68,7 +68,7 @@ class Client
 
         $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
 
-        $isConnected = socket_connect(
+        socket_connect(
             $this->socket,
             $this->connection()->server(),
             $this->connection()->port()
@@ -165,17 +165,10 @@ class Client
             }
             $this->logLine();
             $this->logRead($raw);
-            $messageArray = $parser->parse($raw . "\r\n");
 
-            $message = new RawMessage(
-                $messageArray['nickname'],
-                $messageArray['username'],
-                $messageArray['hostname'],
-                $messageArray['serverName'],
-                $messageArray['command'],
-                $messageArray['params']
+            $message = RawMessage::fromArray(
+                $parser->parse($raw . "\r\n")
             );
-
             $this->dispatcher->dispatch($message);
         }
     }

--- a/src/Irc/Message/Inbound/RawMessage.php
+++ b/src/Irc/Message/Inbound/RawMessage.php
@@ -26,6 +26,24 @@ class RawMessage extends \Spires\Irc\Message\Outbound\RawMessage
         parent::__construct($command, $params);
     }
 
+    /**
+     * Create a RawMessage from the output of Parser::parse()
+     *
+     * @param array $messageParts
+     * @return RawMessage
+     */
+    public static function fromArray($messageParts)
+    {
+        return new RawMessage(
+            $messageParts['nickname'],
+            $messageParts['username'],
+            $messageParts['hostname'],
+            $messageParts['serverName'],
+            $messageParts['command'],
+            $messageParts['params']
+        );
+    }
+
     public static function from(RawMessage $message)
     {
         return new static(

--- a/src/Plugins/BangMessage/Inbound/BangMessage.php
+++ b/src/Plugins/BangMessage/Inbound/BangMessage.php
@@ -7,6 +7,18 @@ use Spires\Plugins\Message\Inbound\Message;
 
 class BangMessage extends Message
 {
+    /**
+     * The bang command
+     * e.g. the message "!somersault mouse acrobat"
+     * would return "somersault" as the bang command
+     *
+     * @return string
+     */
+    public function bangCommand()
+    {
+        return head(explode(' ', $this->text()));
+    }
+
     public function text()
     {
         return ltrim(parent::text(), '!');

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 use Spires\Core\Core;
 use Spires\Irc\Client;
+use Spires\Plugins\Message\Inbound\Message as InboundMessage;
 use Spires\Plugins\Message\Outbound\Message;
 use Spires\Plugins\SystemMessage\Outbound\SystemMessage;
-use Spires\Plugins\Message\Inbound\Message as InboundMessage;
 
 function core(string $abstract = null, array $parameters = [])
 {
@@ -36,4 +36,14 @@ function reply(string $text)
     }, $targets);
 
     send_to($targets, $text);
+}
+
+/**
+ * Returns the first element of the given array
+ *
+ * @param array $array
+ */
+function head($array)
+{
+    return array_values($array)[0];
 }

--- a/tests/Plugins/BangMessage/Inbound/BangMessageTest.php
+++ b/tests/Plugins/BangMessage/Inbound/BangMessageTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Tests for the BangMessage class
+ */
+
+namespace Spires\Tests\Plugins\BangMessage\Inbound;
+
+use Spires\Plugins\BangMessage\Inbound\BangMessage;
+use Spires\Tests\Resources\SpiresTestCase;
+
+class BangMessageTest extends SpiresTestCase
+{
+    /**
+     * @test
+     */
+    function it_returns_the_text_minus_the_bang()
+    {
+        $bangMessage = BangMessage::from($this->newRawMessage("!foo hello world"));
+        assertThat($bangMessage->text(), is("foo hello world"));
+    }
+
+    /**
+     * @test
+     */
+    function it_provides_the_bang_command()
+    {
+        $bangMessage = BangMessage::from($this->newRawMessage("!foo hello world"));
+        assertThat($bangMessage->bangCommand(), is("foo"));
+    }
+}

--- a/tests/Resources/SpiresTestCase.php
+++ b/tests/Resources/SpiresTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spires\Tests\Resources;
+
+use Spires\Irc\Message\Inbound\RawMessage;
+use Spires\Irc\Parser;
+
+/**
+ * Custom test case for Spires stuff
+ */
+class SpiresTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $text
+     * @return RawMessage
+     */
+    protected function newRawMessage($text)
+    {
+        $parser = new Parser();
+        return RawMessage::fromArray(
+            $parser->parse(":FooManChew!~foomanchew@unaffiliated/foomanchew PRIVMSG #phpoxford :{$text}\r\n")
+        );
+    }
+}


### PR DESCRIPTION
I've added BangMessage::bangCommand() - which simply returns the 'command' after the ! e.g. !foo = 'foo' command

I have also added a base test case (SpiresTestCase) which allows you to create a new RawMessage easily with text of your choice. Simple for now, but I had no need of anything more complex.
