### PR TITLE
Few changes to BangMessage

### DIFF
--- a/src/Plugins/BangMessage/Inbound/BangMessage.php
+++ b/src/Plugins/BangMessage/Inbound/BangMessage.php
@@ -16,11 +16,22 @@ class BangMessage extends Message
      */
     public function bangCommand()
     {
-        return head(explode(' ', $this->text()));
+        list($bangCommand, $bangText) = explode(' ', $this->text(), 2);
+
+        return ltrim($bangCommand, '!');
     }
 
-    public function text()
+    /**
+     * The bang text
+     * e.g. the message "!somersault mouse acrobat"
+     * would return "mouse acrobat" as the bang text
+     *
+     * @return string
+     */
+    public function bangText()
     {
-        return ltrim(parent::text(), '!');
+        list($bangCommand, $bangText) = explode(' ', $this->text(), 2);
+
+        return $bangText;
     }
 }

--- a/src/Plugins/BangMessage/Plugin.php
+++ b/src/Plugins/BangMessage/Plugin.php
@@ -14,7 +14,7 @@ class Plugin
      */
     public function createBangMessage(Message $message)
     {
-        if ($message->text()[0] === '!') {
+        if (preg_match('/^![^\s]/', $message->text())) {
             return BangMessage::from($message);
         }
 

--- a/tests/Plugins/BangMessage/Inbound/BangMessageTest.php
+++ b/tests/Plugins/BangMessage/Inbound/BangMessageTest.php
@@ -5,20 +5,11 @@
 
 namespace Spires\Tests\Plugins\BangMessage\Inbound;
 
-use Spires\Plugins\BangMessage\Inbound\BangMessage;
 use Spires\Tests\Resources\SpiresTestCase;
+use Spires\Plugins\BangMessage\Inbound\BangMessage;
 
 class BangMessageTest extends SpiresTestCase
 {
-    /**
-     * @test
-     */
-    function it_returns_the_text_minus_the_bang()
-    {
-        $bangMessage = BangMessage::from($this->newRawMessage("!foo hello world"));
-        assertThat($bangMessage->text(), is("foo hello world"));
-    }
-
     /**
      * @test
      */
@@ -26,5 +17,14 @@ class BangMessageTest extends SpiresTestCase
     {
         $bangMessage = BangMessage::from($this->newRawMessage("!foo hello world"));
         assertThat($bangMessage->bangCommand(), is("foo"));
+    }
+
+    /**
+     * @test
+     */
+    function it_provides_the_bang_params()
+    {
+        $bangMessage = BangMessage::from($this->newRawMessage("!foo hello world"));
+        assertThat($bangMessage->bangText(), is("hello world"));
     }
 }

--- a/tests/Plugins/BangMessage/PluginTest.php
+++ b/tests/Plugins/BangMessage/PluginTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spires\Tests\Plugins\BangMessage;
+
+use Spires\Plugins\BangMessage\Inbound\BangMessage;
+use Spires\Plugins\BangMessage\Plugin;
+use Spires\Plugins\Message\Inbound\Message;
+use Spires\Tests\Resources\SpiresTestCase;
+
+class PluginTest extends SpiresTestCase
+{
+    /**
+     * @test
+     */
+    public function recognize_just_a_bang_command()
+    {
+        $plugin = new Plugin();
+        $message = Message::from($this->newRawMessage("!foo"));
+        $bang = $plugin->createBangMessage($message);
+
+        assertThat($bang, is(anInstanceOf(BangMessage::class)));
+    }
+
+    /**
+     * @test
+     */
+    public function recognize_bang_command_with_additional_text()
+    {
+        $plugin = new Plugin();
+        $message = Message::from($this->newRawMessage("!foo hello world"));
+        $bang = $plugin->createBangMessage($message);
+
+        assertThat($bang, is(anInstanceOf(BangMessage::class)));
+    }
+
+    /**
+     * @test
+     */
+    public function do_not_recognize_if_just_a_bang()
+    {
+        $plugin = new Plugin();
+        $message = Message::from($this->newRawMessage("!"));
+        $bang = $plugin->createBangMessage($message);
+
+        assertThat($bang, is(nullValue()));
+    }
+
+    /**
+     * @test
+     */
+    public function do_not_recognize_if_space_after_bang()
+    {
+        $plugin = new Plugin();
+        $message = Message::from($this->newRawMessage("! foo"));
+        $bang = $plugin->createBangMessage($message);
+
+        assertThat($bang, is(nullValue()));
+    }
+}

--- a/tests/helpersTest.php
+++ b/tests/helpersTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spires;
+
+class helpersTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function head_returns_first_element_of_an_array()
+    {
+        $array = ['a', 'b', 'c', 'd'];
+        $first = head($array);
+
+        assertThat($first, is('a'));
+    }
+
+    /**
+     * @test
+     */
+    public function tail_returns_array_without_first_element()
+    {
+        $array = ['a', 'b', 'c', 'd'];
+        $tail = tail($array);
+
+        assertThat($tail, is(['b', 'c', 'd']));
+    }
+
+}


### PR DESCRIPTION
- Added bangText() to BangMessage
- Removed text() from BangMessage (probably breaking)
- Tests for BangMessage\Plugin and head/tail helpers

Not really sure about the removal of text(), but it should be easily reverted ;)
And the reason for changing thing to use the `list($a, $b) = explode(' ', $string, 2);`, is mostly that we've used that approach in in most of the core plugins so far.
